### PR TITLE
Add support for tpkg versioning that does not follow semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Add a tpkg.json file to the root directory of your project. The follow fields ar
 }
 ```
 
+You can optionally define the app version in the `build.version` property in the tpkg.json file.
+If the version is not defined in tpkg.json then it uses the version in the package.json file.
+
 
 ## Config Options used from package.json
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,14 +17,14 @@ var init = function (projectDir) {
   }
 
   var homeDir = '/home/t/' + pkg.name;
-  var nodeVersion = pkg.hasOwnProperty('engines') ? pkg.engines.node : '0.10.35';
+  var nodeVersion = pkg.hasOwnProperty('engines') ? pkg.engines.node : '0.10.36';
 
 
   var config = {
     project: {
       name: pkg.name,
       description: pkg.description,
-      version: pkg.version,
+      version: tpkgConfig.build.version || pkg.version,
       nodeVersion: nodeVersion,
       startScript: homeDir + '/' + pkg.main,
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tpkg-builder",
   "description": "a build tool for node apps using tpkg (http://tpkg.github.io/)",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Greg Jopa (http://gregjopa.com/)",
   "homepage": "http://github.com/gregjopa/node-tpkg-builder",
   "repository": {

--- a/test/fixtures/example_app/package.json
+++ b/test/fixtures/example_app/package.json
@@ -3,7 +3,7 @@
   "description": "Example express.js web app",
   "version": "1.0.0",
   "engines": {
-    "node": "0.10.33"
+    "node": "0.10.36"
   },
   "private": true,
   "main": "app/index.js",

--- a/test/fixtures/example_app/tpkg.json
+++ b/test/fixtures/example_app/tpkg.json
@@ -6,6 +6,7 @@
   },
   "build": {
     "appFolder": "app",
-    "buildOutputDir": "tpkg_build"
+    "buildOutputDir": "tpkg_build",
+    "version": "1.0.0.0"
   }
 }


### PR DESCRIPTION
With this change the app version can optionally be defined in the tpkg.json file like so:

``` javascript
// tpkg.json
{
  "account": {
    "maintainer": "maintainer@example.com",
    "runAsUser": "webuser",
    "runAsUserGroup": "rolewebusers"
  },
  "build": {
    "appFolder": "app",
    "buildOutputDir": "tpkg_build",
    "version": "1.0.0.0"
  }
}
```

When the version is defined in the tpkg.json file it does not need to follow [semver](http://semver.org/) like does does when defined in package.json. 
